### PR TITLE
Click outside to close nav menu

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import ScrollReveal from "scrollreveal";
 
 import NavBar from "./components/NavBar";
@@ -24,17 +24,25 @@ const scrollReveal = () => {
 };
 
 const App = () => {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
   useEffect(() => {
     scrollReveal();
   }, []);
+
+  const onClick = () => {
+    if (isMenuOpen) {
+      setIsMenuOpen(false);
+    }
+  };
 
   return (
     <div>
       <header className="l-header">
         {/* ===== NAVBAR ===== */}
-        <NavBar />
+        <NavBar isMenuOpen={isMenuOpen} setIsMenuOpen={setIsMenuOpen} />
       </header>
-      <main className="l-main">
+      <main className="l-main" onClick={onClick}>
         {/* ===== HOME ===== */}
         <Home />
         {/* ===== ABOUT ===== */}

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -1,11 +1,8 @@
-import { useState } from "react";
 import NavList from "./NavList";
 
-const NavBar = () => {
-  const [toggleShow, setToggleShow] = useState(false);
-
+const NavBar = (props) => {
   const getClassNameForMenu = () => {
-    return toggleShow ? "nav__menu show" : "nav__menu";
+    return props.isMenuOpen ? "nav__menu show" : "nav__menu";
   };
 
   return (
@@ -23,7 +20,7 @@ const NavBar = () => {
       <div
         className="nav__toggle"
         id="nav-toggle"
-        onClick={() => setToggleShow(!toggleShow)}
+        onClick={() => props.setIsMenuOpen(!props.isMenuOpen)}
       >
         <i className="bx bx-menu"></i>
       </div>

--- a/src/tests/App.test.js
+++ b/src/tests/App.test.js
@@ -39,4 +39,26 @@ describe("test App component", () => {
     expect(ScrollReveal).toHaveBeenCalledTimes(1);
     expect(mockReveal).toHaveBeenCalledTimes(3);
   });
+
+  test("clicks main should close the nav menu if it is open", () => {
+    const mockSetIsMenuOpen = jest.fn();
+    jest
+      .spyOn(React, "useState")
+      .mockImplementation(() => [true, mockSetIsMenuOpen]);
+    const wrapper = shallow(<App />);
+    wrapper.find("main").simulate("click");
+
+    expect(mockSetIsMenuOpen).toHaveBeenCalledWith(false);
+  });
+
+  test("clicks main should do nothing if nav menu is closed", () => {
+    const mockSetIsMenuOpen = jest.fn();
+    jest
+      .spyOn(React, "useState")
+      .mockImplementation(() => [false, mockSetIsMenuOpen]);
+    const wrapper = shallow(<App />);
+    wrapper.find("main").simulate("click");
+
+    expect(mockSetIsMenuOpen).toHaveBeenCalledTimes(0);
+  });
 });

--- a/src/tests/NavBar.test.js
+++ b/src/tests/NavBar.test.js
@@ -5,8 +5,18 @@ import NavBar from "../components/NavBar";
 import NavList from "../components/NavList";
 
 describe("test NavBar component", () => {
+  let mockIsMenuOpen;
+  let mockSetIsMenuOpen;
+
+  beforeEach(() => {
+    mockIsMenuOpen = false;
+    mockSetIsMenuOpen = jest.fn();
+  });
+
   test("renders NavBar correctly", () => {
-    const wrapper = shallow(<NavBar />);
+    const wrapper = shallow(
+      <NavBar isMenuOpen={mockIsMenuOpen} setIsMenuOpen={mockSetIsMenuOpen} />
+    );
 
     expect(wrapper.find("nav").exists()).toBeTruthy();
     expect(wrapper.find(".nav__menu").exists()).toBeTruthy();
@@ -16,9 +26,11 @@ describe("test NavBar component", () => {
     expect(wrapper.find(".nav__toggle").length).toEqual(1);
   });
 
-  test("renders NavBar correctly with true toggle", () => {
-    jest.spyOn(React, "useState").mockImplementation(() => [true, jest.fn()]);
-    const wrapper = shallow(<NavBar />);
+  test("renders NavBar correctly with open menu", () => {
+    mockIsMenuOpen = true;
+    const wrapper = shallow(
+      <NavBar isMenuOpen={mockIsMenuOpen} setIsMenuOpen={mockSetIsMenuOpen} />
+    );
 
     expect(wrapper.find("nav").exists()).toBeTruthy();
     expect(wrapper.find(".nav__menu").exists()).toBeTruthy();
@@ -27,14 +39,11 @@ describe("test NavBar component", () => {
   });
 
   test("clicks nav toggle", () => {
-    const mockToggle = false;
-    const mockSetToggle = jest.fn();
-    jest
-      .spyOn(React, "useState")
-      .mockImplementation(() => [mockToggle, mockSetToggle]);
-    const wrapper = shallow(<NavBar />);
+    const wrapper = shallow(
+      <NavBar isMenuOpen={mockIsMenuOpen} setIsMenuOpen={mockSetIsMenuOpen} />
+    );
     wrapper.find("#nav-toggle").simulate("click");
 
-    expect(mockSetToggle).toHaveBeenCalledWith(!mockToggle);
+    expect(mockSetIsMenuOpen).toHaveBeenCalledWith(!mockIsMenuOpen);
   });
 });


### PR DESCRIPTION
In mobile mode, if the nav menu is currently open, click outside it will have the menu closed.